### PR TITLE
Add 'opls' and 'opls-aa' to possible levels.

### DIFF
--- a/backward.py
+++ b/backward.py
@@ -51,6 +51,8 @@ levels = {
     "amber03":     0,
     "amberGS":     0,
     "slipids":     0, # Amber with adapted lipids
+    "opls":        0,
+    "opls-aa":     0,
     }
 
 


### PR DESCRIPTION
Backward was missing "OPLS" (aka "OPLS-AA") as possible backmapping "levels" which can be used for the resolution transformations.